### PR TITLE
Bump OpenClaw Docker image to 2026.2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ FleetClaw generates configs **for** OpenClaw but doesn't include OpenClaw itself
 **To update OpenClaw:**
 
 ```bash
-docker pull ghcr.io/openclaw/openclaw:2026.2.1
+docker pull ghcr.io/openclaw/openclaw:2026.2.6
 docker compose up -d
 ```
 

--- a/docker/openclaw/Dockerfile
+++ b/docker/openclaw/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/openclaw/openclaw:2026.2.1
+FROM ghcr.io/openclaw/openclaw:2026.2.6
 
 USER root
 RUN apt-get update && \

--- a/templates/docker-compose.yml.j2
+++ b/templates/docker-compose.yml.j2
@@ -95,7 +95,7 @@ services:
     build:
       context: ./docker/openclaw
       dockerfile: Dockerfile
-    image: fleetclaw-openclaw:2026.2.1
+    image: fleetclaw-openclaw:2026.2.6
     container_name: fleetclaw-{{ asset.asset_id | lower }}
 {% if asset.type == 'fleet_coordinator' %}
     restart: unless-stopped

--- a/tests/test_generate_configs.py
+++ b/tests/test_generate_configs.py
@@ -217,7 +217,7 @@ class TestCopyDockerfileToCompose:
         repo_root = tmp_path / 'repo'
         docker_dir = repo_root / 'docker' / 'openclaw'
         docker_dir.mkdir(parents=True)
-        (docker_dir / 'Dockerfile').write_text('FROM ghcr.io/openclaw/openclaw:2026.2.1\n')
+        (docker_dir / 'Dockerfile').write_text('FROM ghcr.io/openclaw/openclaw:2026.2.6\n')
 
         # Setup compose directory
         compose_dir = tmp_path / 'compose'
@@ -229,7 +229,7 @@ class TestCopyDockerfileToCompose:
         # Verify
         dest_docker = compose_dir / 'docker' / 'openclaw'
         assert dest_docker.exists()
-        assert (dest_docker / 'Dockerfile').read_text() == 'FROM ghcr.io/openclaw/openclaw:2026.2.1\n'
+        assert (dest_docker / 'Dockerfile').read_text() == 'FROM ghcr.io/openclaw/openclaw:2026.2.6\n'
 
     def test_copy_dockerfile_skips_when_source_missing(self, tmp_path):
         """Does nothing if source docker directory doesn't exist."""


### PR DESCRIPTION
## Summary
- Bumps OpenClaw Docker base image from `2026.2.1` to `2026.2.6` across Dockerfile, compose template, README, and tests
- Picks up Opus 4.6 forward-compat fallbacks, xAI (Grok) provider, cron scheduling fixes, and security hardening

## Test plan
- [ ] Verify `python -m pytest tests/ -v` passes with updated test assertions
- [ ] Run `python scripts/generate-configs.py --dry-run` to confirm compose template renders correctly
- [ ] Build Docker image: `docker build docker/openclaw/` to confirm base image pulls successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)