### PR TITLE
Fix gateway port to OpenClaw default and correct proxy docs

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -164,7 +164,7 @@ All containers share a single `fleetclaw` bridge network. Agents reach Redis via
 ./skills/{name}/                → /app/skills/{name}            (skills, read-only)
 ```
 
-Clawordinator accesses Docker via a TCP socket proxy (`tecnativa/docker-socket-proxy`) instead of a direct `/var/run/docker.sock` mount. This avoids giving the container root-equivalent access to the host. The proxy container exposes only the Docker API endpoints needed (containers, images, networks) on `tcp://fc-docker-proxy:2375`. Clawordinator connects via `DOCKER_HOST=tcp://fc-docker-proxy:2375`.
+Clawordinator accesses Docker via a TCP socket proxy (`tecnativa/docker-socket-proxy`) instead of a direct `/var/run/docker.sock` mount. This avoids giving the container root-equivalent access to the host. The proxy container exposes only the container management endpoints on `tcp://fc-docker-proxy:2375`. Clawordinator connects via `DOCKER_HOST=tcp://fc-docker-proxy:2375`.
 
 ### Entrypoint
 

--- a/generate-configs.py
+++ b/generate-configs.py
@@ -175,7 +175,7 @@ def generate_compose_service_asset(asset: dict, fleet: dict) -> dict:
             },
             "restart": "unless-stopped",
             "healthcheck": {
-                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
+                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:18789/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
                 "interval": "60s",
                 "timeout": "10s",
                 "retries": 3,
@@ -227,7 +227,7 @@ def generate_compose_service_clawvisor(fleet: dict) -> dict:
             },
             "restart": "unless-stopped",
             "healthcheck": {
-                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
+                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:18789/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
                 "interval": "60s",
                 "timeout": "10s",
                 "retries": 3,
@@ -299,7 +299,7 @@ def generate_compose_service_clawordinator(fleet: dict) -> dict:
             },
             "restart": "unless-stopped",
             "healthcheck": {
-                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:8080/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
+                "test": ["CMD", "node", "-e", "require('http').get('http://localhost:18789/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"],
                 "interval": "60s",
                 "timeout": "10s",
                 "retries": 3,

--- a/templates/openclaw-asset.json
+++ b/templates/openclaw-asset.json
@@ -1,7 +1,7 @@
 {
   "gateway": {
     "mode": "local",
-    "port": 8080,
+    "port": 18789,
     "bind": "loopback"
   },
   "agents": {

--- a/templates/openclaw-clawordinator.json
+++ b/templates/openclaw-clawordinator.json
@@ -1,7 +1,7 @@
 {
   "gateway": {
     "mode": "local",
-    "port": 8080,
+    "port": 18789,
     "bind": "loopback"
   },
   "agents": {

--- a/templates/openclaw-clawvisor.json
+++ b/templates/openclaw-clawvisor.json
@@ -1,7 +1,7 @@
 {
   "gateway": {
     "mode": "local",
-    "port": 8080,
+    "port": 18789,
     "bind": "loopback"
   },
   "agents": {


### PR DESCRIPTION
## Summary

- **Gateway port 8080 → 18789**: All three `openclaw.json` templates and all three healthcheck URLs in `generate-configs.py` used port 8080, but OpenClaw's actual default gateway port is 18789. Updated all 6 locations.
- **Docker proxy docs fix**: `docs/implementation.md` overstated that the socket proxy exposes "containers, images, networks" — the code only sets `CONTAINERS=1` and `POST=1`. Corrected to "container management endpoints".

## Test plan

- [x] Grep confirms zero remaining `8080` references in repo
- [x] Grep confirms zero remaining "images, networks" claims in docs
- [x] `python generate-configs.py` runs cleanly against `fleet.yaml.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)