### PR TITLE
Fix OpenClaw config docs against live deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Data flows: Asset Agents → (outbox files) → Clawvisor → (escalations) → 
    - Copy the appropriate SOUL.md template from `templates/`
    - Create inbox/outbox directories
    - Configure skills (point OpenClaw at the skills directory)
-   - Tune openclaw.json (heartbeat, activeHours, bootstrapMaxChars)
+   - Tune openclaw.json (agents.defaults: heartbeat, bootstrapMaxChars, model)
    - Set ACLs (permissions doc)
    - Create env file with secrets
    - Create and start the system service (platform doc)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,7 +216,7 @@ MEMORY.md is the agent's hot cache — curated context loaded at session start. 
 
 ### The 15,000 character constraint
 
-FleetClaw sets `bootstrapMaxChars` to 15,000 characters (down from OpenClaw's 20,000 default) to leave headroom for skills context. Each agent role has a dedicated memory-curator skill that defines structure, pruning rules, and character budgets.
+FleetClaw sets `agents.defaults.bootstrapMaxChars` to 15,000 characters (down from OpenClaw's 20,000 default) to leave headroom for skills context. Each agent role has a dedicated memory-curator skill that defines structure, pruning rules, and character budgets.
 
 ### Per-agent-role design
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -56,17 +56,17 @@ Tune based on:
 Configure in each agent's `openclaw.json`:
 
 ```json
-"heartbeat": {
-  "every": "30m",
-  "activeHours": {
-    "start": "06:00",
-    "end": "18:00",
-    "timezone": "Australia/Perth"
+"agents": {
+  "defaults": {
+    "heartbeat": {
+      "every": "30m",
+      "prompt": "Run heartbeat tasks from your mounted skills."
+    }
   }
 }
 ```
 
-`activeHours` is the primary cost control — agents don't heartbeat outside shift hours.
+Heartbeat interval is the primary cost control — longer intervals reduce API costs.
 
 ## Adapting SOUL.md templates
 

--- a/platform/macos.md
+++ b/platform/macos.md
@@ -72,9 +72,9 @@ Create one plist per agent at `/Library/LaunchDaemons/com.fleetclaw.agent.{id}.p
 
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/node</string>
-        <string>/Users/fc-ex001/.openclaw/dist/index.js</string>
+        <string>/usr/local/bin/openclaw</string>
         <string>gateway</string>
+        <string>--force</string>
     </array>
 
     <key>WorkingDirectory</key>
@@ -88,6 +88,8 @@ Create one plist per agent at `/Library/LaunchDaemons/com.fleetclaw.agent.{id}.p
         <string>your-token-here</string>
         <key>FLEET_MD_PATH</key>
         <string>/opt/fleetclaw/fleet.md</string>
+        <key>NODE_OPTIONS</key>
+        <string>--max-old-space-size=768</string>
     </dict>
 
     <key>RunAtLoad</key>
@@ -105,10 +107,11 @@ Create one plist per agent at `/Library/LaunchDaemons/com.fleetclaw.agent.{id}.p
     <key>StandardErrorPath</key>
     <string>/var/log/fleetclaw/fc-agent-ex001.err</string>
 
+    <!-- 1 GB for asset agents; use 1610612736 (1.5 GB) for Clawvisor/Clawordinator -->
     <key>SoftResourceLimits</key>
     <dict>
         <key>MemoryLock</key>
-        <integer>536870912</integer>
+        <integer>1073741824</integer>
     </dict>
 </dict>
 </plist>

--- a/platform/ubuntu.md
+++ b/platform/ubuntu.md
@@ -31,6 +31,9 @@ Repeat for each agent: `fc-clawvisor`, `fc-clawordinator`, and each asset agent.
 
 ```bash
 su -s /bin/bash fc-ex001 -c "command here"
+
+# For CLI commands that need env vars (e.g., openclaw pairing, channels):
+sudo su -s /bin/bash fc-ex001 -c "source /opt/fleetclaw/env/ex001.env && openclaw <command>"
 ```
 
 ## Package management
@@ -67,26 +70,27 @@ Type=simple
 User=fc-{id}
 Group=fc-agents
 WorkingDirectory=/home/fc-{id}/.openclaw
-ExecStart=/usr/bin/node /home/fc-{id}/.openclaw/dist/index.js gateway
+ExecStart=/usr/bin/openclaw gateway --force
 Restart=on-failure
 RestartSec=10
 EnvironmentFile=/opt/fleetclaw/env/{id}.env
 
-# Resource limits
-MemoryMax=512M
+# Resource limits — use 1536M for Clawvisor/Clawordinator
+MemoryMax=1G
 CPUQuota=25%
 
 # Security hardening
 NoNewPrivileges=yes
 ProtectSystem=strict
-ReadWritePaths=/home/fc-{id}/.openclaw
+PrivateTmp=no
+ReadWritePaths=/home/fc-{id}/.openclaw /tmp
 ReadOnlyPaths=/opt/fleetclaw/skills /opt/fleetclaw/fleet.md
 
 [Install]
 WantedBy=multi-user.target
 ```
 
-For Clawvisor and Clawordinator, adjust `MemoryMax` to `1G` and add appropriate `ReadWritePaths` for inbox access to other agents (see `docs/permissions.md`).
+For Clawvisor and Clawordinator, set `MemoryMax=1536M` and add appropriate `ReadWritePaths` for inbox access to other agents (see `docs/permissions.md`).
 
 ### Service commands
 
@@ -193,6 +197,7 @@ cat > /opt/fleetclaw/env/ex001.env << 'EOF'
 FIREWORKS_API_KEY=your-key-here
 TELEGRAM_BOT_TOKEN=your-token-here
 FLEET_MD_PATH=/opt/fleetclaw/fleet.md
+NODE_OPTIONS=--max-old-space-size=768
 EOF
 
 chown fc-ex001:root /opt/fleetclaw/env/ex001.env

--- a/platform/windows.md
+++ b/platform/windows.md
@@ -56,7 +56,7 @@ choco install nssm
 ### Create a service
 
 ```powershell
-nssm install fc-agent-ex001 "C:\Program Files\nodejs\node.exe" "C:\FleetClaw\agents\fc-ex001\.openclaw\dist\index.js" gateway
+nssm install fc-agent-ex001 "C:\Program Files\nodejs\openclaw.cmd" gateway --force
 
 # Set working directory
 nssm set fc-agent-ex001 AppDirectory "C:\FleetClaw\agents\fc-ex001\.openclaw"
@@ -74,8 +74,8 @@ nssm set fc-agent-ex001 AppRestartDelay 10000
 nssm set fc-agent-ex001 AppStdout "C:\FleetClaw\logs\fc-agent-ex001.log"
 nssm set fc-agent-ex001 AppStderr "C:\FleetClaw\logs\fc-agent-ex001.err"
 
-# Set memory limit (512 MB)
-nssm set fc-agent-ex001 AppEnvironmentExtra+ "NODE_OPTIONS=--max-old-space-size=384"
+# Set memory limit (1 GB for assets, 1.5 GB for supervisory)
+nssm set fc-agent-ex001 AppEnvironmentExtra+ "NODE_OPTIONS=--max-old-space-size=768"
 ```
 
 ### Service commands

--- a/skills/asset-onboarder/SKILL.md
+++ b/skills/asset-onboarder/SKILL.md
@@ -45,7 +45,7 @@ Once validated, the following steps bring the new asset agent online. Reference 
    - Copy the SOUL.md template from `templates/soul-asset.md`, substituting `{ASSET_ID}` and `{SERIAL}` with the actual values
    - Create `inbox/` and `outbox/` directories in the workspace
    - Mount or copy the appropriate skills (fuel-logger, meter-reader, pre-op, issue-reporter, nudger, memory-curator-asset)
-   - Tune `openclaw.json` settings: `bootstrapMaxChars: 15000`, heartbeat interval, shift configuration
+   - Tune `openclaw.json` `agents.defaults`: `bootstrapMaxChars: 15000`, heartbeat interval
 
 5. **Set file permissions** using the platform's ACL mechanism. The asset agent user needs read/write on its own workspace. Clawvisor needs read access to this agent's outbox/ and state.md, and write access to its inbox/. See `docs/permissions.md` for the specific ACL rules.
 
@@ -53,7 +53,7 @@ Once validated, the following steps bring the new asset agent online. Reference 
 
 7. **Update fleet.md** — add the new asset ID to the Active section with today's date.
 
-8. **Remind user about messaging channel configuration.** The new agent needs its own messaging channel token/configuration to function. After confirming the service is running, remind the user to configure the agent's messaging channel credentials in the environment file.
+8. **Set up messaging channel.** The new agent needs its own messaging channel. After confirming the service is running: enable the messaging plugin (`openclaw plugins enable telegram`), add the channel with the bot token (`openclaw channels add --channel telegram --token <token>`), and restart the agent service. Remind the user that users must be paired via `openclaw pairing approve` before they can message the agent.
 
 ### Confirm to user
 


### PR DESCRIPTION
## Summary

- Fix config nesting: `skipBootstrap`, `bootstrapMaxChars`, `heartbeat`, `sandbox`, `compaction` belong under `agents.defaults`, not at root level
- Remove all `activeHours` references (not supported in OpenClaw 2026.2.6)
- Add complete LLM provider setup (`models.providers` with `models.mode: "merge"`) and model allowlist (`agents.defaults.models`)
- Add new "Messaging channel setup" section covering plugin enable, channel add, user pairing, and env sourcing
- Fix memory limits across all platform docs: 512MB → 1GB (assets), 1GB → 1.5GB (supervisory), with `NODE_OPTIONS` in env files
- Fix `ExecStart` in all platform docs: `node dist/index.js gateway` → `openclaw gateway --force`
- Document `ProtectSystem=strict` fix (`PrivateTmp=no` + `/tmp` in `ReadWritePaths`), port relay collisions, and restart sequencing
- Update setup checklists with new steps for messaging plugin, user pairing, and LLM provider config

## Test plan

- [x] `grep -r "activeHours"` returns zero matches
- [x] `grep -r "dist/index.js" platform/` returns zero matches
- [x] `grep -r "512" platform/` returns zero matches for memory limits
- [x] All `skipBootstrap`/`bootstrapMaxChars` references show correct `agents.defaults.` prefix
- [ ] Read through `docs/implementation.md` end-to-end for consistency
- [ ] Verify all three platform docs have consistent memory limits and ExecStart patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)