### PR TITLE
Add OpenClaw upgrade documentation

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -38,6 +38,46 @@ Each agent runs as its own system user. For each agent:
 2. **Install OpenClaw as that user** — Run `openclaw onboard --install-daemon` under the agent's user account. This sets up the OpenClaw runtime in `~/.openclaw/`.
 3. **Verify** — The `~/.openclaw/` directory should contain `dist/`, `openclaw.json`, and `workspace/`.
 
+## Upgrading OpenClaw
+
+All agents on a host share the same globally-installed OpenClaw binary (`/usr/bin/openclaw` on Linux, `/usr/local/bin/openclaw` on macOS, `openclaw.cmd` on Windows). Upgrading the global package upgrades every agent simultaneously — no per-agent updates needed.
+
+### Upgrade procedure
+
+1. **Check current version:**
+   ```bash
+   openclaw --version
+   ```
+
+2. **Stop all agent services on the host.** Stop everything first, then start everything after — this avoids relay port race conditions (see "System service configuration" below for why). See the platform docs for OS-specific stop commands.
+
+3. **Update the global package:**
+   ```bash
+   sudo npm install -g openclaw@<version>
+   ```
+   Use `openclaw@latest` for the latest stable release, or pin a specific version. Alternatively: `sudo npm update -g openclaw`.
+
+4. **Verify new version:**
+   ```bash
+   openclaw --version
+   ```
+
+5. **Start all agent services.** See the platform docs for OS-specific start commands.
+
+6. **Verify services are running.** Gateway warmup takes 3-4 minutes while TypeScript plugins compile — services may report as active before the agent is fully responsive. Check logs to confirm the gateway is ready.
+
+### Rollback
+
+Same procedure: stop services, install the previous version (`sudo npm install -g openclaw@<previous-version>`), start services.
+
+### Breaking changes
+
+Check OpenClaw release notes before upgrading. If a release changes config format, update all agents' `openclaw.json` files while services are stopped.
+
+### What doesn't change
+
+For non-breaking upgrades, `openclaw.json` and service configuration files (systemd units, launchd plists, NSSM settings) remain unchanged. ExecStart points to the global binary, which npm replaces in-place.
+
 ## FleetClaw injection
 
 After OpenClaw is installed, customize each agent's workspace:

--- a/platform/macos.md
+++ b/platform/macos.md
@@ -133,6 +133,25 @@ launchctl list | grep fleetclaw
 tail -f /var/log/fleetclaw/fc-agent-ex001.log
 ```
 
+### Upgrading OpenClaw
+
+```bash
+# 1. Stop all agents
+launchctl unload /Library/LaunchDaemons/com.fleetclaw.agent.*.plist
+
+# 2. Update global package
+sudo npm install -g openclaw@<version>
+
+# 3. Verify version
+openclaw --version
+
+# 4. Start all agents
+launchctl load /Library/LaunchDaemons/com.fleetclaw.agent.*.plist
+
+# 5. Check status
+launchctl list | grep fleetclaw
+```
+
 ## File permissions (macOS ACLs)
 
 macOS uses a different ACL syntax from Linux. Use `chmod +a` instead of `setfacl`.

--- a/platform/ubuntu.md
+++ b/platform/ubuntu.md
@@ -113,6 +113,31 @@ systemctl restart fc-agent-ex001
 systemctl disable fc-agent-ex001
 ```
 
+### Upgrading OpenClaw
+
+```bash
+# 1. Stop all agent services
+sudo systemctl stop fc-agent-*
+
+# 2. Verify all stopped
+systemctl is-active fc-agent-* 2>&1 | grep -v inactive
+# (no output = all stopped)
+
+# 3. Update global package
+sudo npm install -g openclaw@<version>
+
+# 4. Verify version
+openclaw --version
+
+# 5. Start all agent services
+sudo systemctl start fc-agent-*
+
+# 6. Verify all running (wait ~30s for startup)
+systemctl is-active fc-agent-*
+```
+
+The `fc-agent-*` wildcard works with systemctl. For selective upgrades (if agents are split across hosts), list specific service names instead.
+
 ### Reload after unit file changes
 
 ```bash

--- a/platform/windows.md
+++ b/platform/windows.md
@@ -97,6 +97,27 @@ nssm status fc-agent-ex001
 nssm remove fc-agent-ex001 confirm
 ```
 
+### Upgrading OpenClaw
+
+```powershell
+# 1. Stop all agent services
+Get-Service fc-agent-* | Stop-Service
+
+# 2. Update global package
+npm install -g openclaw@<version>
+
+# 3. Verify version
+openclaw --version
+
+# 4. Start all agent services
+Get-Service fc-agent-* | Start-Service
+
+# 5. Check status
+Get-Service fc-agent-* | Format-Table Name, Status
+```
+
+NSSM services are registered as standard Windows services, so `Get-Service`/`Stop-Service`/`Start-Service` work. Alternatively, use `nssm stop fc-agent-ex001` per agent.
+
 ## File permissions (NTFS ACLs)
 
 ### Grant Clawvisor read access to asset outbox


### PR DESCRIPTION
## Summary

- Adds version-agnostic upgrade procedure to `docs/implementation.md` (between install and injection sections): check version, stop all services, update global npm package, verify, start all, verify running. Includes rollback and breaking-change guidance.
- Adds OS-specific upgrade commands to all three platform docs: `systemctl` for Ubuntu, `launchctl` for macOS, `Get-Service`/PowerShell for Windows.
- No hardcoded version numbers — all use `<version>` placeholders.

## Test plan

- [ ] Read `docs/implementation.md` — "Upgrading OpenClaw" section flows naturally between "Per-user OpenClaw installation" and "FleetClaw injection"
- [ ] Read each platform doc — upgrade subsection sits logically after service commands
- [ ] `grep -r "Upgrading OpenClaw" docs/ platform/` returns matches in all 4 files
- [ ] Confirm no version numbers are hardcoded in the new content

🤖 Generated with [Claude Code](https://claude.com/claude-code)