### PR TITLE
Add openclaw doctor --fix to upgrade procedure

### DIFF
--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -63,9 +63,15 @@ All agents on a host share the same globally-installed OpenClaw binary (`/usr/bi
    openclaw --version
    ```
 
-5. **Start all agent services.** See the platform docs for OS-specific start commands.
+5. **Run config migration on each agent** (while services are still stopped):
+   ```bash
+   sudo -u fc-ex001 bash -c "source /opt/fleetclaw/env/ex001.env && openclaw doctor --fix"
+   ```
+   Repeat for each agent. This migrates openclaw.json to the new version's config schema (creates a `.bak` backup). Ignore "Config invalid" warnings — doctor can't resolve `${ENV_VAR}` references outside systemd, but proceeds in best-effort mode. At runtime, the EnvironmentFile supplies the values.
 
-6. **Verify services are running.** Gateway warmup takes 3-4 minutes while TypeScript plugins compile — services may report as active before the agent is fully responsive. Check logs to confirm the gateway is ready.
+6. **Start all agent services.** See the platform docs for OS-specific start commands.
+
+7. **Verify services are running.** Gateway warmup takes 3-4 minutes while TypeScript plugins compile — services may report as active before the agent is fully responsive. Check logs to confirm the gateway is ready.
 
 ### Rollback
 
@@ -73,7 +79,7 @@ Same procedure: stop services, install the previous version (`sudo npm install -
 
 ### Breaking changes
 
-Check OpenClaw release notes before upgrading. If a release changes config format, update all agents' `openclaw.json` files while services are stopped.
+Check OpenClaw release notes before upgrading. `openclaw doctor --fix` handles most config schema migrations automatically. For changes that require manual intervention, update all agents' `openclaw.json` files while services are stopped.
 
 ### What doesn't change
 

--- a/platform/macos.md
+++ b/platform/macos.md
@@ -145,10 +145,15 @@ sudo npm install -g openclaw@<version>
 # 3. Verify version
 openclaw --version
 
-# 4. Start all agents
+# 4. Run config migration on each agent
+for id in ex001 ex002 ex003 clawvisor clawordinator; do
+  sudo -u fc-$id openclaw doctor --fix
+done
+
+# 5. Start all agents
 launchctl load /Library/LaunchDaemons/com.fleetclaw.agent.*.plist
 
-# 5. Check status
+# 6. Check status
 launchctl list | grep fleetclaw
 ```
 

--- a/platform/ubuntu.md
+++ b/platform/ubuntu.md
@@ -129,10 +129,15 @@ sudo npm install -g openclaw@<version>
 # 4. Verify version
 openclaw --version
 
-# 5. Start all agent services
+# 5. Run config migration on each agent
+for id in ex001 ex002 ex003 clawvisor clawordinator; do
+  sudo -u fc-$id bash -c "source /opt/fleetclaw/env/$id.env && openclaw doctor --fix"
+done
+
+# 6. Start all agent services
 sudo systemctl start fc-agent-*
 
-# 6. Verify all running (wait ~30s for startup)
+# 7. Verify all running (wait ~30s for startup)
 systemctl is-active fc-agent-*
 ```
 

--- a/platform/windows.md
+++ b/platform/windows.md
@@ -109,10 +109,17 @@ npm install -g openclaw@<version>
 # 3. Verify version
 openclaw --version
 
-# 4. Start all agent services
+# 4. Run config migration on each agent
+$agents = @("ex001", "ex002", "ex003", "clawvisor", "clawordinator")
+foreach ($id in $agents) {
+    Start-Process -FilePath "openclaw.cmd" -ArgumentList "doctor --fix" `
+        -WorkingDirectory "C:\FleetClaw\agents\fc-$id\.openclaw" -NoNewWindow -Wait
+}
+
+# 5. Start all agent services
 Get-Service fc-agent-* | Start-Service
 
-# 5. Check status
+# 6. Check status
 Get-Service fc-agent-* | Format-Table Name, Status
 ```
 


### PR DESCRIPTION
## Summary
- Adds `openclaw doctor --fix` as a new step in the upgrade procedure (between version verification and service start) across all docs
- Updates `docs/implementation.md` generic procedure (now 7 steps) with the command, expected warnings explanation, and updated breaking changes paragraph
- Updates `platform/ubuntu.md`, `platform/macos.md`, and `platform/windows.md` upgrade scripts with OS-appropriate `doctor --fix` loops

## Test plan
- [x] Verify step numbering is sequential (1-7 in implementation.md, platform-appropriate in each OS doc)
- [x] Confirm `doctor --fix` command uses correct env file path pattern (`/opt/fleetclaw/env/{id}.env`)
- [x] Confirm macOS variant omits `source` (plists embed env vars directly)
- [x] Confirm Windows variant uses `Start-Process` with `-WorkingDirectory` pointing to agent `.openclaw` dir
- [x] Grep repo for stale references to old step counts — none found
- [x] Tested `openclaw doctor --fix` on live deployment (all agents, v2026.2.14) — config migration succeeded on every agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)